### PR TITLE
A fix for issue: https://github.com/Lisiadito/join-lines-plugin/issues/2

### DIFF
--- a/joinLines.lua
+++ b/joinLines.lua
@@ -29,7 +29,7 @@ function joinLines()
     end    
 
     -- swarp all whitespaces with a single space
-    local modifiedSelection = string.gsub(selection, "%s+", " ")
+    local modifiedSelection = string.gsub(selection, "\n%s+", " ")
     -- write modified selection to buffer
     v.Buf:Replace(a, b, modifiedSelection)    
 end


### PR DESCRIPTION
Note, I think the repository is out of sync with the releases or something, if you install via the micro plugin system you get version 1.1.0, but the repository still has version 1.0.0 in the joinLines.lua file and the init commands are not within an init method.