### PR TITLE
Fix problem deleting spaces

### DIFF
--- a/joinLines.lua
+++ b/joinLines.lua
@@ -1,46 +1,30 @@
-VERSION = "1.0.3"
+VERSION = "1.1.0"
 
-function joinLines()
-    local v = CurView()
-    local a, b, c = nil, nil, v.Cursor
-    local selection = c:GetSelection()
+local micro = import("micro")
+local config = import("micro/config")
 
-    if c:HasSelection() then
-        if c.CurSelection[1]:GreaterThan(-c.CurSelection[2]) then
-            a, b = c.CurSelection[2], c.CurSelection[1]
-        else
-            a, b = c.CurSelection[1], c.CurSelection[2]
-        end
-        a = Loc(a.X, a.Y)
-        b = Loc(b.X, b.Y)
-        selection = c:GetSelection()
-    else
-        -- get beginning of curent line
-        local startLoc = Loc(0, c.Loc.Y)  
-        -- get the last position of the next line 
-        -- I use the go function because Lua string.len counts bytes which leads
-        -- to wrong results with some unicode characters
-        local xNext = utf8.RuneCountInString(v.Buf:Line(c.Loc.Y+1))
+function joinLines(v)
+    local nLines = 1
+    local cursor = v.Cursor
 
-        a = startLoc
-        b = Loc(xNext, c.Loc.Y+1)
+    if cursor:HasSelection() then
+        local b, a = cursor.CurSelection[1], cursor.CurSelection[2]
+        nLines = math.abs(a.Y - b.Y)
+    end
 
-		if a.x ~= b.x then 
-        	c:SetSelectionStart(startLoc)
-        	c:SetSelectionEnd(b)
-        	selection = c:GetSelection()
-       	end
-    end    
-
-	if a.x ~= b.x then 
-    	-- swap all whitespaces with a single space
-    	local modifiedSelection = string.gsub(selection, "\n%s*", " ")
-    	-- write modified selection to buffer
-    	v.Buf:Replace(a, b, modifiedSelection)    
-   	end
+    for _ = 1, nLines, 1 do
+        v:EndOfLine()
+        v:Delete()
+        v.Buf:Insert(-cursor.Loc, " ")
+        v:SelectWordRight()
+        v:SelectWordLeft()
+        v:Delete()
+        v:EndOfLine()
+    end
 end
 
-MakeCommand("joinLines", "joinLines.joinLines")
-BindKey("Alt-j", "joinLines.joinLines")
-
-AddRuntimeFile("joinLines", "help", "help/join-lines-plugin.md")
+function init()
+    config.MakeCommand("joinLines", joinLines, config.NoComplete)
+    config.TryBindKey("Alt-j", "lua:joinLines.joinLines", false)
+    config.AddRuntimeFile("joinLines", config.RTHelp, "help/join-lines-plugin.md")
+end


### PR DESCRIPTION
When executing the spaces at the beginning of the first line of the selection where gone.
Also spaces at the beginning of the last line of selection still there, and should be removed.
I made kind of a macro, which is also a but easier to reason about.

After making this PR and seeing that the version changed, I did some digging and found that the main repo is here: https://github.com/micro-editor/updated-plugins/tree/master/join-lines-plugin

How can we push this change there? Do I have to do a PR there? or you as maintainer do it?

Kind regards and stay inside.