### PR TITLE
Fix broken install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This plugin provides the ability to join selected lines in micro.
 
-Install with `> plugin install join-lines`.
+Open the command prompt in `micro` by pressing `Ctrl-E`.
 
-The default shotcut is `alt-j` to join the current line with the next one. It also works to select multiple lines at once.
+Install with `> plugin install joinLines`.
+
+The default keybinding to join the current line with the next one is `Alt-J` . It also works when select multiple lines at once.


### PR DESCRIPTION
I noticed that the install command in the README was no longer up-to-date and therefore broken.
Thanks for creating the plugin!