### PR TITLE
doc: fix incorrect keybinding

### DIFF
--- a/help/join-lines-plugin.md
+++ b/help/join-lines-plugin.md
@@ -5,6 +5,6 @@ but you can easily modify that in your `bindings.json` file:
 
 ```json
 {
-    "Alt-k": "joinLines.joinLines"
+    "Alt-k": "lua:joinLines.joinLines"
 }
 ```


### PR DESCRIPTION
`joinLines.joinLines` binding doesn't work, so let's change it to the correct one, to not confuse users.

See also https://github.com/zyedidia/micro/commit/24406a5ae80f0742f6970aad0e083f64bb421551